### PR TITLE
Internal server error fix

### DIFF
--- a/resources/lang/en/translation.php
+++ b/resources/lang/en/translation.php
@@ -868,6 +868,6 @@ return [
     "Insert_YouTube_Video" => "Insert YouTube Video",
     "YouTube_embedded_successfully" => "YouTube video embedded successfully!",
     "Invalid_YouTube_URL" => "Invalid YouTube URL",
-    "Write_your_reply_here" => "Write your reply here..."
+    "Write_your_reply_here" => "Write your reply here...",
     "Enter_your_signature_here" => "Enter your signature here"
 ];


### PR DESCRIPTION
A "," was missing in ressources/lang/en/translation.php, which was causing a internal server error